### PR TITLE
fixed crash when selecting cells from different months consecutively

### DIFF
--- a/Calendar/ViewController.swift
+++ b/Calendar/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
         }
     }
     
-    func handleCellTextColor(view: JTAppleCell, cellState: CellState) {
+    func handleCellTextColor(view: JTAppleCell?, cellState: CellState) {
         guard let validCell = view as? CustomCell else { return }
         
         if validCell.isSelected {
@@ -51,7 +51,7 @@ class ViewController: UIViewController {
         }
     }
     
-    func handleCellSelected(view: JTAppleCell, cellState: CellState) {
+    func handleCellSelected(view: JTAppleCell?, cellState: CellState) {
         guard let validCell = view as? CustomCell else { return }
         
         if validCell.isSelected {
@@ -114,13 +114,13 @@ extension ViewController: JTAppleCalendarViewDelegate {
     }
     
     func calendar(_ calendar: JTAppleCalendarView, didSelectDate date: Date, cell: JTAppleCell?, cellState: CellState) {
-        handleCellSelected(view: cell!, cellState: cellState)
-        handleCellTextColor(view: cell!, cellState: cellState)
+        handleCellSelected(view: cell, cellState: cellState)
+        handleCellTextColor(view: cell, cellState: cellState)
     }
     
     func calendar(_ calendar: JTAppleCalendarView, didDeselectDate date: Date, cell: JTAppleCell?, cellState: CellState) {
-        handleCellSelected(view: cell!, cellState: cellState)
-        handleCellTextColor(view: cell!, cellState: cellState)
+        handleCellSelected(view: cell, cellState: cellState)
+        handleCellTextColor(view: cell, cellState: cellState)
     }
     
     func calendar(_ calendar: JTAppleCalendarView, didScrollToDateSegmentWith visibleDates: DateSegmentInfo) {


### PR DESCRIPTION
your app would crash if you selected a date in one month, then attempted to select a date in another